### PR TITLE
Add utility methods to add/retrieve a clock to/from a context

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Small go library for mocking parts of the [time](https://golang.org/pkg/time) and [context](https://golang.org/pkg/context) packages.
 
-## Time utilities
+## Time Utilities
 
 The package contains a `Clock` and `Ticker` interface that wrap the `time.Now`, `time.After`, and `time.Sleep` functions and the `Ticker` struct, respectively.
 
@@ -60,9 +60,47 @@ clock.Advance(time.Second * 30)
 clock.Advance(time.Second * 30) // Fires ch
 ```
 
-## Context utilities
+## Context Utilities
 
-The package also contains the functions `ContextWithDeadline` and `ContextWithTimeout` that mimmic the `context.WithDeadline` and `context.WithTimeout` functions, but will use a user-provided `Clock` instance rather than the standard `time.After` function.
+If you'd like to use a `context.Context` as a way to make a glock `Clock` available, this
+package provides `WithContext` and `FromContext` utility methods.
+
+To add a `Clock` to a context you would call `WithContext` and provide a parent context as well
+as the `Clock` you'd like to add.
+
+```go
+clock := glock.NewMockClock()
+
+ctx := context.Background()
+ctx = glock.WithContext(ctx, clock)
+```
+
+To retrieve the `Clock` from a context, the `FromContext` method is available. If a `Clock`
+does not already exist within the context `FromContext` will return a new *real* clock instance.
+
+```go
+// Retrieve a mock clock from the context
+clock := glock.NewMockClock()
+
+ctx := context.Background()
+ctx = glock.WithContext(ctx, clock)
+
+ctxClock := glock.FromContext(ctx)
+```
+
+```go
+// Retrieve a default real clock from the context
+ctx := context.Background()
+ctx = glock.WithContext(ctx, clock)
+
+ctxClock := glock.FromContext(ctx)
+```
+
+## Context Testing Utilities
+
+The package also contains the functions `ContextWithDeadline` and `ContextWithTimeout` that
+mimic the `context.WithDeadline` and `context.WithTimeout` functions, but will use a
+user-provided `Clock` instance rather than the standard `time.After` function.
 
 A *real* clock can be used for non-test scenarios without much additional overhead.
 
@@ -74,7 +112,9 @@ defer cancel()
 <-ctx.Done() // Waits 1s
 ```
 
-In order to make unit tests that depend on context timeouts deterministic, a *mock* clock can be used in place of the real clock. The mock clock can be advanced in the same was a described in the previous section.
+In order to make unit tests that depend on context timeouts deterministic, a *mock* clock can
+be used in place of the real clock. The mock clock can be advanced in the same was a described
+in the previous section.
 
 ```go
 clock := glock.NewMockClock()
@@ -91,7 +131,7 @@ go func() {
 
 ## License
 
-Copyright (c) 20202 Eric Fritz
+Copyright (c) 2021 Eric Fritz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/context.go
+++ b/context.go
@@ -6,6 +6,27 @@ import (
 	"time"
 )
 
+type ctxKey struct{}
+
+var glockCtxKey = &ctxKey{}
+
+// WithContext returns a context derived from the provided context with
+// the provided Clock as a value.
+func WithContext(ctx context.Context, clock Clock) context.Context {
+	return context.WithValue(ctx, glockCtxKey, clock)
+}
+
+// FromContext retrieves the Clock value from the provided context. If a Clock
+// is not set on the context a new real clock will be returned.
+func FromContext(ctx context.Context) Clock {
+	clock, ok := ctx.Value(glockCtxKey).(Clock)
+	if !ok {
+		clock = NewRealClock()
+	}
+
+	return clock
+}
+
 type glockAwareContext struct {
 	context.Context
 	mu   sync.Mutex

--- a/context_test.go
+++ b/context_test.go
@@ -8,11 +8,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestContextValues(t *testing.T) {
+	t.Run("value can be added to and retrieved from context", func(t *testing.T) {
+		t.Parallel()
+
+		clock := NewMockClock()
+
+		ctx := context.Background()
+		ctx = WithContext(ctx, clock)
+
+		ctxClock := FromContext(ctx)
+		assert.Same(t, clock, ctxClock)
+	})
+	t.Run("default to returning real clock", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		ctxClock := FromContext(ctx)
+		assert.NotNil(t, ctxClock)
+		assert.IsType(t, &realClock{}, ctxClock)
+	})
+}
+
 func TestContext(t *testing.T) {
+	t.Parallel()
+
 	testContextWithTimeout(t, func(state *contextTestState) {})
 }
 
 func TestContextCancelParent(t *testing.T) {
+	t.Parallel()
+
 	testContextWithTimeout(t, func(state *contextTestState) {
 		state.err1 = context.Canceled
 		state.err2 = context.Canceled
@@ -22,6 +49,8 @@ func TestContextCancelParent(t *testing.T) {
 }
 
 func TestContextCancel(t *testing.T) {
+	t.Parallel()
+
 	testContextWithTimeout(t, func(state *contextTestState) {
 		state.err2 = context.Canceled
 		state.err3 = context.Canceled
@@ -30,6 +59,8 @@ func TestContextCancel(t *testing.T) {
 }
 
 func TestContextCancelChild(t *testing.T) {
+	t.Parallel()
+
 	testContextWithTimeout(t, func(state *contextTestState) {
 		state.err3 = context.Canceled
 		state.cancel3()
@@ -37,6 +68,8 @@ func TestContextCancelChild(t *testing.T) {
 }
 
 func TestContextDeadline(t *testing.T) {
+	t.Parallel()
+
 	testContextWithTimeout(t, func(state *contextTestState) {
 		state.err2 = context.DeadlineExceeded
 		state.err3 = context.DeadlineExceeded

--- a/mock_clock_test.go
+++ b/mock_clock_test.go
@@ -29,6 +29,8 @@ func TestSetCurrent(t *testing.T) {
 }
 
 func TestAdvance(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	clock.SetCurrent(time.Unix(100, 0))
 	assert.Equal(t, time.Unix(100, 0), clock.Now())
@@ -39,6 +41,8 @@ func TestAdvance(t *testing.T) {
 }
 
 func TestAdvanceMultipleTriggers(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	results := make(chan time.Time)
 
@@ -70,6 +74,8 @@ func TestAdvanceMultipleTriggers(t *testing.T) {
 }
 
 func TestBlockingAdvance(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	sync := make(chan struct{})
 	done := make(chan time.Time)
@@ -93,6 +99,8 @@ func TestBlockingAdvance(t *testing.T) {
 }
 
 func TestGetAfterArgs(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 
 	clock.After(3 * time.Second)
@@ -113,6 +121,8 @@ func TestGetAfterArgs(t *testing.T) {
 }
 
 func TestAfter(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	clock.SetCurrent(time.Unix(0, 0))
 
@@ -134,6 +144,8 @@ func TestAfter(t *testing.T) {
 }
 
 func TestMultipleAfter(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	clock.SetCurrent(time.Unix(0, 0))
 
@@ -165,6 +177,8 @@ func TestMultipleAfter(t *testing.T) {
 }
 
 func TestAfterNotExact(t *testing.T) {
+	t.Parallel()
+
 	// Make sure triggers are still fired even if the
 	// time doesn't match up exactly with the trigger
 	clock := NewMockClock()
@@ -179,6 +193,8 @@ func TestAfterNotExact(t *testing.T) {
 }
 
 func TestAfterTriggersSorted(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	clock.SetCurrent(time.Unix(0, 0))
 
@@ -199,6 +215,8 @@ func TestAfterTriggersSorted(t *testing.T) {
 }
 
 func TestRemoveAfterTrigger(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	clock.SetCurrent(time.Unix(0, 0))
 
@@ -224,6 +242,8 @@ func TestRemoveAfterTrigger(t *testing.T) {
 }
 
 func TestBlockedOnAfter(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 
 	assert.Equal(t, 0, clock.BlockedOnAfter())
@@ -253,6 +273,8 @@ func TestBlockedOnAfter(t *testing.T) {
 }
 
 func TestSleep(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	clock.SetCurrent(time.Unix(0, 0))
 
@@ -281,6 +303,8 @@ func TestSleep(t *testing.T) {
 }
 
 func TestSince(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClockAt(time.Unix(10, 0))
 
 	assert.Equal(t, time.Duration(0), clock.Since(time.Unix(10, 0)))
@@ -289,6 +313,8 @@ func TestSince(t *testing.T) {
 }
 
 func TestUntil(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClockAt(time.Unix(10, 0))
 
 	assert.Equal(t, time.Duration(0), clock.Until(time.Unix(10, 0)))

--- a/mock_ticker_test.go
+++ b/mock_ticker_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestGetTickerArgs(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 
 	clock.NewTicker(3 * time.Second)
@@ -28,11 +30,15 @@ func TestGetTickerArgs(t *testing.T) {
 }
 
 func TestNewTickerNoDuration(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	assert.Panics(t, func() { clock.NewTicker(0) })
 }
 
 func TestTickerOnTime(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	clock.SetCurrent(time.Unix(0, 0))
 
@@ -88,6 +94,8 @@ func main() {
 }
 */
 func TestTickerOffset2Second(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	clock.SetCurrent(time.Unix(0, 0))
 
@@ -149,6 +157,8 @@ func main() {
 }
 */
 func TestTickerOffset3Second(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	clock.SetCurrent(time.Unix(0, 0))
 
@@ -184,6 +194,8 @@ func TestTickerOffset3Second(t *testing.T) {
 }
 
 func TestMultipleTickers(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	clock.SetCurrent(time.Unix(0, 0))
 
@@ -216,6 +228,8 @@ func TestMultipleTickers(t *testing.T) {
 }
 
 func TestTickerStopped(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	clock.SetCurrent(time.Unix(0, 0))
 


### PR DESCRIPTION
I was working on some code recently and realized that it would be useful to provide methods to transmit a clock around. I think it's a good fit because it's purely informational and it makes it easier to integrate glock into an existing codebase given the ubiquity of contexts.

I also made some small formatting fixes and made most of the tests run in parallel to cut down test runtime from ~7s to ~1s.