### PR TITLE
Expose advance mechanism to timers

### DIFF
--- a/advanceable.go
+++ b/advanceable.go
@@ -1,0 +1,80 @@
+package glock
+
+import (
+	"sync"
+	"time"
+)
+
+type Advanceable interface {
+	Advance(duration time.Duration)
+	BlockingAdvance(duration time.Duration)
+	SetCurrent(now time.Time)
+}
+
+// advanceable is the base type for mock clocks and tickers. This struct is
+// written to be used as as a mixin, where the containing struct can mutate
+// its internals (assuming correct coordination is used).
+//
+// An "advanceable" struct has a current time set of subscribers that may
+// change over time. The current time can be moved explicitly by the user.
+type advanceable struct {
+	now         time.Time
+	subscribers []subscriber
+	m           *sync.Mutex
+	cond        *sync.Cond
+}
+
+type subscriber interface {
+	// signal performs some behavior if the given current time is after a
+	// deadline registered previously. This method should not block. If the
+	// subscriber is still interested in being updated with the current
+	// time, it should return true; the clock or timer instance will drop
+	// a reference to this subscriber otherwise.
+	signal(now time.Time) (requeue bool)
+}
+
+// newAdvanceableAt returns a new advanceable struct with the given current time.
+func newAdvanceableAt(now time.Time) *advanceable {
+	m := &sync.Mutex{}
+
+	return &advanceable{
+		now:  now,
+		m:    m,
+		cond: sync.NewCond(m),
+	}
+}
+
+// Advance will advance the clock's internal time by the given duration.
+func (a *advanceable) Advance(duration time.Duration) {
+	a.m.Lock()
+	a.setCurrent(a.now.Add(duration))
+	a.m.Unlock()
+}
+
+// SetCurrent sets the clock's internal time to the given time.
+func (a *advanceable) SetCurrent(now time.Time) {
+	a.m.Lock()
+	a.setCurrent(now)
+	a.m.Unlock()
+}
+
+// setCurrent sets the new current time and invokes and filters the list of
+// subscribers.
+func (a *advanceable) setCurrent(now time.Time) {
+	filtered := a.subscribers[:0]
+	for _, e := range a.subscribers {
+		if e.signal(now) {
+			filtered = append(filtered, e)
+		}
+	}
+
+	a.now = now
+	a.subscribers = filtered
+	a.cond.Broadcast()
+}
+
+// register marks a subscriber to be updated when the current time changes.
+func (a *advanceable) register(subscriber subscriber) {
+	a.subscribers = append(a.subscribers, subscriber)
+	a.cond.Broadcast()
+}

--- a/mock_clock.go
+++ b/mock_clock.go
@@ -1,14 +1,17 @@
 package glock
 
 import (
-	"runtime"
-	"sort"
-	"sync"
 	"time"
 )
 
-// Clock is a wrapper around common functions in the time package.
-// This interface is designed to allow easy mocking of time functions.
+var closedChan = make(chan time.Time)
+
+func init() {
+	close(closedChan)
+}
+
+// Clock is a wrapper around common functions in the time package. This interface
+// is designed to allow easy mocking of time functions.
 type Clock interface {
 	// Now returns the current time.
 	Now() time.Time
@@ -35,174 +38,123 @@ type Clock interface {
 // in increments for testing code that relies on timeouts or other time-sensitive
 // constructs.
 type MockClock struct {
-	fakeTime   time.Time
-	triggers   mockTriggers
-	tickers    mockTickers
+	*advanceable
 	afterArgs  []time.Duration
 	tickerArgs []time.Duration
-	nowLock    sync.RWMutex
-	afterLock  sync.RWMutex
-	tickerLock sync.Mutex
 }
 
 var _ Clock = &MockClock{}
+var _ Advanceable = &MockClock{}
 
-type mockTrigger struct {
-	trigger time.Time
-	ch      chan time.Time
-}
-
-type mockTriggers []*mockTrigger
-type mockTickers []*mockTicker
-
-// NewMockClock creates a new MockClock with the internal time set
-// to time.Now()
+// NewMockClock creates a new MockClock with the internal time set to time.Now().
 func NewMockClock() *MockClock {
 	return NewMockClockAt(time.Now())
 }
 
-// NewMockClockAt creates a new MockClick with the internal time set
-// to the provided time.
+// NewMockClockAt creates a new MockClick with the internal time set to the given time.
 func NewMockClockAt(now time.Time) *MockClock {
-	return &MockClock{
-		fakeTime:   now,
-		tickers:    make([]*mockTicker, 0),
-		afterArgs:  make([]time.Duration, 0),
-		tickerArgs: make([]time.Duration, 0),
-	}
+	return &MockClock{advanceable: newAdvanceableAt(now)}
 }
 
-// SetCurrent sets the internal MockClock time to the supplied time.
-func (mc *MockClock) SetCurrent(current time.Time) {
-	mc.nowLock.Lock()
-	defer mc.nowLock.Unlock()
+// Now returns the clock's internal time.
+func (c *MockClock) Now() time.Time {
+	c.m.Lock()
+	defer c.m.Unlock()
 
-	mc.fakeTime = current
+	return c.now
 }
 
-// Advance will advance the internal MockClock time by the supplied time.
-func (mc *MockClock) Advance(duration time.Duration) {
-	mc.nowLock.Lock()
-	now := mc.fakeTime.Add(duration)
-	mc.fakeTime = now
-	mc.nowLock.Unlock()
+// After returns a channel that will be sent the clock's internal time once the
+// clock's internal time is at or past the supplied duration.
+func (c *MockClock) After(duration time.Duration) <-chan time.Time {
+	c.m.Lock()
+	defer c.m.Unlock()
 
-	mc.processTriggers(now)
-	mc.processTickers(now)
-}
+	c.afterArgs = append(c.afterArgs, duration)
 
-func (mc *MockClock) processTriggers(now time.Time) {
-	mc.afterLock.Lock()
-	defer mc.afterLock.Unlock()
-
-	triggered := 0
-	for _, trigger := range mc.triggers {
-		if trigger.trigger.Before(now) || trigger.trigger.Equal(now) {
-			trigger.ch <- trigger.trigger
-			triggered++
-		}
+	if duration <= 0 {
+		return closedChan
 	}
 
-	mc.triggers = mc.triggers[triggered:]
+	ch := make(chan time.Time, 1)
+	deadline := c.now.Add(duration)
+	c.register(&afterSubscriber{ch: ch, deadline: deadline})
+	return ch
 }
 
-func (mc *MockClock) processTickers(now time.Time) {
-	mc.tickerLock.Lock()
-	defer mc.tickerLock.Unlock()
-
-	for _, ticker := range mc.tickers {
-		ticker.publish(now)
-	}
+// BlockedOnAfter returns the number of calls to After that are blocked waiting for
+// a call to Advance to trigger them.
+func (c *MockClock) BlockedOnAfter() int {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return len(c.subscribers)
 }
 
-// BlockingAdvance will call Advance but only after there is another routine
-// which is blocking on the channel result of a call to After.
-func (mc *MockClock) BlockingAdvance(duration time.Duration) {
-	for mc.BlockedOnAfter() == 0 {
-		runtime.Gosched()
-	}
-
-	mc.Advance(duration)
-}
-
-// Now returns the current time internal to the MockClock
-func (mc *MockClock) Now() time.Time {
-	mc.nowLock.RLock()
-	defer mc.nowLock.RUnlock()
-
-	return mc.fakeTime
-}
-
-// After returns a channel that will be sent the current internal MockClock
-// time once the MockClock's internal time is at or past the provided duration
-func (mc *MockClock) After(duration time.Duration) <-chan time.Time {
-	mc.nowLock.RLock()
-	triggerTime := mc.fakeTime.Add(duration)
-	mc.nowLock.RUnlock()
-
-	mc.afterLock.Lock()
-	defer mc.afterLock.Unlock()
-
-	trigger := &mockTrigger{
-		trigger: triggerTime,
-		ch:      make(chan time.Time, 1),
-	}
-
-	mc.triggers = append(mc.triggers, trigger)
-	mc.afterArgs = append(mc.afterArgs, duration)
-
-	sort.Slice(mc.triggers, func(i, j int) bool {
-		return mc.triggers[i].trigger.Before(mc.triggers[j].trigger)
-	})
-
-	return trigger.ch
-}
-
-// BlockedOnAfter returns the number of calls to After that are blocked
-// waiting for a call to Advance to trigger them.
-func (mc *MockClock) BlockedOnAfter() int {
-	mc.afterLock.RLock()
-	defer mc.afterLock.RUnlock()
-
-	return len(mc.triggers)
-}
-
-// Sleep will block until the internal MockClock time is at or past the
-// provided duration
-func (mc *MockClock) Sleep(duration time.Duration) {
-	<-mc.After(duration)
+// Sleep will block until the clock's internal time is at or past the given duration.
+func (c *MockClock) Sleep(duration time.Duration) {
+	<-c.After(duration)
 }
 
 // Since returns the time elapsed since t.
-func (mc *MockClock) Since(t time.Time) time.Duration {
-	return mc.Now().Sub(t)
+func (c *MockClock) Since(t time.Time) time.Duration {
+	return c.Now().Sub(t)
 }
 
 // Until returns the duration until t.
-func (mc *MockClock) Until(t time.Time) time.Duration {
-	return t.Sub(mc.Now())
+func (c *MockClock) Until(t time.Time) time.Duration {
+	return t.Sub(c.Now())
+}
+
+// BlockingAdvance will call Advance but only after there is another goroutine
+// with a reference to a new channel returned by the After method.
+func (c *MockClock) BlockingAdvance(duration time.Duration) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	for len(c.subscribers) == 0 {
+		c.cond.Wait()
+	}
+
+	c.setCurrent(c.now.Add(duration))
 }
 
 // GetAfterArgs returns the duration of each call to After in the
 // same order as they were called. The list is cleared each time
 // GetAfterArgs is called.
-func (mc *MockClock) GetAfterArgs() []time.Duration {
-	mc.afterLock.Lock()
-	defer mc.afterLock.Unlock()
+func (c *MockClock) GetAfterArgs() []time.Duration {
+	c.m.Lock()
+	defer c.m.Unlock()
 
-	args := mc.afterArgs
-	mc.afterArgs = mc.afterArgs[:0]
+	args := c.afterArgs
+	c.afterArgs = c.afterArgs[:0]
 	return args
 }
 
 // GetTickerArgs returns the duration of each call to create a new
 // ticker in the same order as they were called. The list is cleared
 // each time GetTickerArgs is called.
-func (mc *MockClock) GetTickerArgs() []time.Duration {
-	mc.tickerLock.Lock()
-	defer mc.tickerLock.Unlock()
+func (c *MockClock) GetTickerArgs() []time.Duration {
+	c.m.Lock()
+	defer c.m.Unlock()
 
-	args := mc.tickerArgs
-	mc.tickerArgs = mc.tickerArgs[:0]
+	args := c.tickerArgs
+	c.tickerArgs = c.tickerArgs[:0]
 	return args
+}
+
+type afterSubscriber struct {
+	ch       chan time.Time
+	deadline time.Time
+}
+
+// signal conforms to the subscriber interface.
+func (s *afterSubscriber) signal(now time.Time) (requeue bool) {
+	if now.Before(s.deadline) {
+		// not enough time elapsed
+		// try again on the next signal
+		return true
+	}
+
+	s.ch <- s.deadline // inform user
+	return false       // unsubscribe
 }

--- a/mock_clock_test.go
+++ b/mock_clock_test.go
@@ -13,13 +13,13 @@ func TestNewMockClock(t *testing.T) {
 	// instead of an exact time
 	clock := NewMockClock()
 
-	since := time.Since(clock.fakeTime)
+	since := time.Since(clock.Now())
 	assert.Condition(t, func() bool { return since < 100*time.Millisecond })
 }
 
 func TestNow(t *testing.T) {
 	clock := NewMockClock()
-	assert.Equal(t, clock.fakeTime, clock.Now())
+	assert.Equal(t, clock.Now(), clock.Now())
 }
 
 func TestSetCurrent(t *testing.T) {
@@ -190,55 +190,6 @@ func TestAfterNotExact(t *testing.T) {
 	clock.Advance(3 * time.Second)
 	eventually(t, chanReceives(a1, time.Unix(1, 0)))
 	eventually(t, chanReceives(a2, time.Unix(2, 0)))
-}
-
-func TestAfterTriggersSorted(t *testing.T) {
-	t.Parallel()
-
-	clock := NewMockClock()
-	clock.SetCurrent(time.Unix(0, 0))
-
-	clock.After(3 * time.Second)
-	assert.Len(t, clock.triggers, 1)
-	assert.Equal(t, time.Unix(3, 0), clock.triggers[0].trigger)
-
-	clock.After(1 * time.Second)
-	assert.Len(t, clock.triggers, 2)
-	assert.Equal(t, time.Unix(1, 0), clock.triggers[0].trigger)
-	assert.Equal(t, time.Unix(3, 0), clock.triggers[1].trigger)
-
-	clock.After(2 * time.Second)
-	assert.Len(t, clock.triggers, 3)
-	assert.Equal(t, time.Unix(1, 0), clock.triggers[0].trigger)
-	assert.Equal(t, time.Unix(2, 0), clock.triggers[1].trigger)
-	assert.Equal(t, time.Unix(3, 0), clock.triggers[2].trigger)
-}
-
-func TestRemoveAfterTrigger(t *testing.T) {
-	t.Parallel()
-
-	clock := NewMockClock()
-	clock.SetCurrent(time.Unix(0, 0))
-
-	clock.After(1 * time.Second)
-	clock.After(2 * time.Second)
-	clock.After(3 * time.Second)
-	assert.Len(t, clock.triggers, 3)
-	assert.Equal(t, time.Unix(1, 0), clock.triggers[0].trigger)
-	assert.Equal(t, time.Unix(2, 0), clock.triggers[1].trigger)
-	assert.Equal(t, time.Unix(3, 0), clock.triggers[2].trigger)
-
-	clock.Advance(1 * time.Second)
-	assert.Len(t, clock.triggers, 2)
-	assert.Equal(t, time.Unix(2, 0), clock.triggers[0].trigger)
-	assert.Equal(t, time.Unix(3, 0), clock.triggers[1].trigger)
-
-	clock.Advance(1 * time.Second)
-	assert.Len(t, clock.triggers, 1)
-	assert.Equal(t, time.Unix(3, 0), clock.triggers[0].trigger)
-
-	clock.Advance(1 * time.Second)
-	assert.Len(t, clock.triggers, 0)
 }
 
 func TestBlockedOnAfter(t *testing.T) {

--- a/mock_ticker.go
+++ b/mock_ticker.go
@@ -1,13 +1,9 @@
 package glock
 
-import (
-	"sync"
-	"time"
-)
+import "time"
 
-// Ticker is a wrapper around a time.Ticker, which allows interface
-// access  to the underlying channel (instead of bare access like the
-// time.Ticker struct allows).
+// Ticker is a wrapper around a time.Ticker, which allows interface access to the
+// underlying channel (instead of bare access like the time.Ticker struct allows).
 type Ticker interface {
 	// Chan returns the underlying ticker channel.
 	Chan() <-chan time.Time
@@ -16,126 +12,108 @@ type Ticker interface {
 	Stop()
 }
 
-type mockTicker struct {
-	clock        *MockClock
-	duration     time.Duration
-	started      time.Time
-	nextTick     time.Time
-	processQueue []time.Time
-	ch           chan time.Time
-	wakeup       chan struct{}
-	stopped      bool
-	processLock  sync.Mutex
-	stoppedLock  sync.RWMutex
+// MockTicker is an implementation of Ticker that can be moved forward in time
+// in increments for testing code that relies on timeouts or other time-sensitive
+// constructs.
+type MockTicker struct {
+	*advanceable
+	duration time.Duration
+	deadline time.Time
+	ch       chan time.Time
+	stopped  bool
 }
 
-var _ Ticker = &mockTicker{}
+var _ Ticker = &MockTicker{}
+var _ Advanceable = &MockTicker{}
 
 // NewTicker creates a new Ticker tied to the internal MockClock time that ticks
 // at intervals similar to time.NewTicker().  It will also skip or drop ticks
 // for slow readers similar to time.NewTicker() as well.
-func (mc *MockClock) NewTicker(duration time.Duration) Ticker {
+func (c *MockClock) NewTicker(duration time.Duration) Ticker {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	c.tickerArgs = append(c.tickerArgs, duration)
+
+	return newMockTickerAt(c.advanceable, duration)
+}
+
+// NewMockTicker creates a new MockTicker with the internal time set to time.Now().
+func NewMockTicker(duration time.Duration) *MockTicker {
+	return NewMockTickerAt(time.Now(), duration)
+}
+
+// NewMockTickerAt creates a new MockTicker with the internal time set to the given time.
+func NewMockTickerAt(now time.Time, duration time.Duration) *MockTicker {
+	return newMockTickerAt(newAdvanceableAt(now), duration)
+}
+
+func newMockTickerAt(advanceable *advanceable, duration time.Duration) *MockTicker {
 	if duration == 0 {
 		panic("duration cannot be 0")
 	}
 
-	now := mc.Now()
-	ticker := &mockTicker{
-		clock:        mc,
-		duration:     duration,
-		started:      now,
-		nextTick:     now.Add(duration),
-		processQueue: make([]time.Time, 0),
-		ch:           make(chan time.Time),
-		wakeup:       make(chan struct{}, 1),
+	t := &MockTicker{
+		advanceable: advanceable,
+		duration:    duration,
+		deadline:    advanceable.now.Add(duration),
+		ch:          make(chan time.Time),
 	}
 
-	mc.tickerLock.Lock()
-	defer mc.tickerLock.Unlock()
-
-	mc.tickers = append(mc.tickers, ticker)
-	mc.tickerArgs = append(mc.tickerArgs, duration)
-	go ticker.process()
-	return ticker
+	go t.process()
+	advanceable.register(t)
+	return t
 }
 
-// Chan returns a channel which will receive the MockClock's internal time
-// at the interval given when creating the ticker.
-func (mt *mockTicker) Chan() <-chan time.Time {
-	return mt.ch
+// Chan returns a channel which will receive the tickers's internal time at the
+// interval given when creating the ticker.
+func (t *MockTicker) Chan() <-chan time.Time {
+	return t.ch
 }
 
-// Stop will stop the ticker from ticking
-func (mt *mockTicker) Stop() {
-	mt.stoppedLock.Lock()
-	defer mt.stoppedLock.Unlock()
+// Stop will stop the ticker from ticking.
+func (t *MockTicker) Stop() {
+	t.cond.L.Lock()
+	defer t.cond.L.Unlock()
 
-	mt.stopped = true
-	mt.wakeup <- struct{}{}
+	t.stopped = true
+	t.cond.Broadcast()
 }
 
-func (mt *mockTicker) publish(now time.Time) {
-	if mt.isStopped() {
-		return
-	}
+// BlockingAdvance will bump the ticker's internal time by the given duration. If
+// If the new internal time passes the next tick threshold, a signal will be sent.
+// This method will not return until the signal is read by a consumer of the
+// ticker.
+func (t *MockTicker) BlockingAdvance(duration time.Duration) {
+	t.m.Lock()
+	defer t.m.Unlock()
 
-	mt.processLock.Lock()
-	mt.processQueue = append(mt.processQueue, now)
-	mt.processLock.Unlock()
+	t.now = t.now.Add(duration)
 
-	select {
-	case mt.wakeup <- struct{}{}:
-	default:
+	if !t.now.Before(t.deadline) {
+		t.ch <- t.deadline
+		t.deadline = t.deadline.Add(t.duration)
 	}
 }
 
-func (mt *mockTicker) process() {
-	defer close(mt.wakeup)
+func (t *MockTicker) process() {
+	t.cond.L.Lock()
+	defer t.cond.L.Unlock()
 
-	for !mt.isStopped() {
-		for {
-			first, ok := mt.pop()
-			if !ok {
-				break
-			}
+	for !t.stopped {
+		if !t.now.Before(t.deadline) {
+			t.ch <- t.deadline
 
-			if mt.nextTick.After(first) {
-				continue
-			}
-
-			mt.ch <- mt.nextTick
-
-			durationMod := first.Sub(mt.started) % mt.duration
-
-			if durationMod == 0 {
-				mt.nextTick = first.Add(mt.duration)
-			} else if first.Sub(mt.nextTick) > mt.duration {
-				mt.nextTick = first.Add(mt.duration - durationMod)
-			} else {
-				mt.nextTick = mt.nextTick.Add(mt.duration)
+			for !t.now.Before(t.deadline) {
+				t.deadline = t.deadline.Add(t.duration)
 			}
 		}
 
-		<-mt.wakeup
+		t.cond.Wait()
 	}
 }
 
-func (mt *mockTicker) pop() (time.Time, bool) {
-	mt.processLock.Lock()
-	defer mt.processLock.Unlock()
-
-	if len(mt.processQueue) == 0 {
-		return time.Unix(0, 0), false
-	}
-
-	first := mt.processQueue[0]
-	mt.processQueue = mt.processQueue[1:]
-	return first, true
-}
-
-func (mt *mockTicker) isStopped() bool {
-	mt.stoppedLock.RLock()
-	defer mt.stoppedLock.RUnlock()
-
-	return mt.stopped
+// signal conforms to the subscriber interface.
+func (t *MockTicker) signal(now time.Time) (requeue bool) {
+	return !t.stopped
 }

--- a/real_clock.go
+++ b/real_clock.go
@@ -33,6 +33,10 @@ func (c *realClock) Until(t time.Time) time.Duration {
 }
 
 func (c *realClock) NewTicker(duration time.Duration) Ticker {
+	return NewRealTicker(duration)
+}
+
+func NewRealTicker(duration time.Duration) Ticker {
 	return &realTicker{
 		ticker: time.NewTicker(duration),
 	}


### PR DESCRIPTION
This is a behavior-preserving change that cleans up the internals and adds a few extra capabilities:

- Users can now create timers unattached to a clock and use `Advance`/`BlockingAdvance`/`SetCurrent` directly on timers. This makes it possible to precisely test timer behavior without having to resort to calling `Advance` in a retry loop.
- The three methods mentioned above are now in an interface called `Advanceable`, to which both mock clocks and timers conform.