### PR TITLE
Add support for time.Timer type and time.AfterFunc function

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ go func() {
 
 ## License
 
-Copyright (c) 2021 Eric Fritz
+Copyright (c) 2022 Eric Fritz, Kristin Davidson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/clock.go
+++ b/clock.go
@@ -1,0 +1,36 @@
+package glock
+
+import "time"
+
+// Clock is a wrapper around common functions in the time package. This interface
+// is designed to allow easy mocking of time functions.
+type Clock interface {
+	// Now returns the current time.
+	Now() time.Time
+
+	// After returns a channel which receives the current time after
+	// the given duration elapses.
+	After(duration time.Duration) <-chan time.Time
+
+	// Sleep blocks until the given duration elapses.
+	Sleep(duration time.Duration)
+
+	// Since returns the time elapsed since t.
+	Since(t time.Time) time.Duration
+
+	// Until returns the duration until t.
+	Until(t time.Time) time.Duration
+
+	// NewTicker will construct a ticker which will continually fire,
+	// pausing for the given duration in between invocations.
+	NewTicker(duration time.Duration) Ticker
+
+	// NewTimer will construct a timer which will fire once after the
+	// given duration.
+	NewTimer(duration time.Duration) Timer
+
+	// AfterFunc waits for the duration to elapse and then calls f in
+	// its own goroutine. It returns a Timer that can be used to cancel the call
+	// using its Stop method.
+	AfterFunc(duration time.Duration, f func()) Timer
+}

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,13 @@
 module github.com/derision-test/glock
 
-go 1.15
+go 1.18
+
+require github.com/stretchr/testify v1.6.1
 
 require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
-	github.com/stretchr/testify v1.6.1
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -27,7 +27,7 @@ func consistentlyNot(t *testing.T, cond func() bool) bool {
 	return consistently(t, func() bool { return !cond() })
 }
 
-func chanClosed(ch <-chan time.Time) func() bool {
+func chanClosed[T any](ch <-chan T) func() bool {
 	return func() bool {
 		select {
 		case _, ok := <-ch:

--- a/mock_clock.go
+++ b/mock_clock.go
@@ -10,30 +10,6 @@ func init() {
 	close(closedChan)
 }
 
-// Clock is a wrapper around common functions in the time package. This interface
-// is designed to allow easy mocking of time functions.
-type Clock interface {
-	// Now returns the current time.
-	Now() time.Time
-
-	// After returns a channel which receives the current time after
-	// the given duration elapses.
-	After(duration time.Duration) <-chan time.Time
-
-	// Sleep blocks until the given duration elapses.
-	Sleep(duration time.Duration)
-
-	// Since returns the time elapsed since t.
-	Since(t time.Time) time.Duration
-
-	// Until returns the duration until t.
-	Until(t time.Time) time.Duration
-
-	// NewTicker will construct a ticker which will continually fire,
-	// pausing for the given duration in between invocations.
-	NewTicker(duration time.Duration) Ticker
-}
-
 // MockClock is an implementation of Clock that can be moved forward in time
 // in increments for testing code that relies on timeouts or other time-sensitive
 // constructs.

--- a/mock_ticker.go
+++ b/mock_ticker.go
@@ -2,16 +2,6 @@ package glock
 
 import "time"
 
-// Ticker is a wrapper around a time.Ticker, which allows interface access to the
-// underlying channel (instead of bare access like the time.Ticker struct allows).
-type Ticker interface {
-	// Chan returns the underlying ticker channel.
-	Chan() <-chan time.Time
-
-	// Stop stops the ticker.
-	Stop()
-}
-
 // MockTicker is an implementation of Ticker that can be moved forward in time
 // in increments for testing code that relies on timeouts or other time-sensitive
 // constructs.

--- a/mock_timer.go
+++ b/mock_timer.go
@@ -1,0 +1,131 @@
+package glock
+
+import (
+	"time"
+)
+
+func sendTime(t *MockTimer) {
+	t.ch <- t.now
+}
+
+type MockTimer struct {
+	*advanceable
+	deadline time.Time
+	ch       chan time.Time
+	stopped  bool
+	f        func(*MockTimer)
+}
+
+var _ Timer = &MockTimer{}
+var _ Advanceable = &MockTimer{}
+
+func (c *MockClock) NewTimer(duration time.Duration) Timer {
+	return newMockTimerAt(c.advanceable, duration, sendTime)
+}
+
+func (c *MockClock) AfterFunc(duration time.Duration, f func()) Timer {
+	return newMockTimerAt(c.advanceable, duration, func(mt *MockTimer) {
+		go f()
+	})
+}
+
+func NewMockTimer(duration time.Duration) *MockTimer {
+	return NewMockTimerAt(time.Now(), duration)
+}
+
+func NewMockTimerAt(now time.Time, duration time.Duration) *MockTimer {
+	return newMockTimerAt(newAdvanceableAt(now), duration, sendTime)
+}
+
+func newMockTimerAt(
+	advanceable *advanceable,
+	duration time.Duration,
+	f func(*MockTimer),
+) *MockTimer {
+	if duration == 0 {
+		panic("duration cannot be 0")
+	}
+
+	t := &MockTimer{
+		advanceable: advanceable,
+		deadline:    advanceable.now.Add(duration),
+		ch:          make(chan time.Time),
+		f:           f,
+	}
+
+	go t.process()
+	advanceable.register(t)
+
+	return t
+}
+
+func (t *MockTimer) Chan() <-chan time.Time {
+	return t.ch
+}
+
+func (t *MockTimer) Reset(duration time.Duration) bool {
+	t.cond.L.Lock()
+	defer t.cond.L.Unlock()
+
+	wasRunning := !t.stopped
+
+	t.deadline = t.now.Add(duration)
+	t.stopped = false
+
+	if !wasRunning {
+		go t.process()
+		t.advanceable.register(t)
+	}
+
+	t.cond.Broadcast()
+
+	return wasRunning
+}
+
+func (t *MockTimer) Stop() bool {
+	t.cond.L.Lock()
+	defer t.cond.L.Unlock()
+
+	if t.stopped {
+		return false
+	}
+
+	t.stopped = true
+	t.cond.Broadcast()
+
+	return true
+}
+
+func (t *MockTimer) BlockingAdvance(duration time.Duration) {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	t.now = t.now.Add(duration)
+
+	t.tryExecute()
+	// TODO Test this
+}
+
+func (t *MockTimer) tryExecute() {
+	if !t.now.Before(t.deadline) {
+		t.stopped = true
+		t.cond.Broadcast()
+
+		t.f(t)
+	}
+}
+
+func (t *MockTimer) process() {
+	t.cond.L.Lock()
+	defer t.cond.L.Unlock()
+
+	for !t.stopped {
+		t.tryExecute()
+		t.cond.Wait()
+	}
+
+}
+
+func (t *MockTimer) signal(now time.Time) bool {
+	return !t.stopped
+}

--- a/mock_timer_test.go
+++ b/mock_timer_test.go
@@ -1,0 +1,334 @@
+package glock
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockTimer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("new timer", func(t *testing.T) {
+		t.Run("no duration", func(t *testing.T) {
+			clock := NewMockClock()
+			assert.Panics(t, func() { clock.NewTimer(0) })
+		})
+	})
+	t.Run("blocking advance", func(t *testing.T) {
+		t.Run("blocks until channel is read", func(t *testing.T) {
+			clock := NewMockClockAt(time.Unix(0, 0))
+			timer := clock.NewTimer(1 * time.Second).(*MockTimer)
+
+			finishedBlocking := make(chan struct{})
+			go func() {
+				// This should close immediately because it doesn't
+				// trigger the timer.
+				timer.BlockingAdvance(500 * time.Millisecond)
+				close(finishedBlocking)
+			}()
+			eventually(t, chanClosed(finishedBlocking))
+			assert.Equal(t, time.Unix(0, 500000000), clock.Now())
+
+			finishedBlocking = make(chan struct{})
+			go func() {
+				// This should block until the signal chan is read
+				// because it triggers the timer.
+				timer.BlockingAdvance(500 * time.Millisecond)
+				close(finishedBlocking)
+			}()
+			eventually(t, chanReceives(timer.Chan(), time.Unix(1, 0)))
+			eventually(t, chanClosed(finishedBlocking))
+			assert.Equal(t, time.Unix(1, 0), clock.Now())
+		})
+		t.Run("does not block for AfterFunc", func(t *testing.T) {
+			// It doesn't make sense for blocking advance to block
+			// on AfterFunc because it's not writing to the signal
+			// channel.
+			funcCalled := uint32(0)
+
+			clock := NewMockClockAt(time.Unix(0, 0))
+			timer := clock.AfterFunc(1*time.Second, func() {
+				atomic.AddUint32(&funcCalled, 1)
+			}).(*MockTimer)
+
+			finishedBlocking := make(chan struct{})
+			go func() {
+				// This should close immediately because it doesn't
+				// trigger the timer.
+				timer.BlockingAdvance(500 * time.Millisecond)
+				close(finishedBlocking)
+			}()
+			consistently(t, chanDoesNotReceive(timer.Chan()))
+			eventually(t, chanClosed(finishedBlocking))
+			consistently(t, func() bool { return atomic.LoadUint32(&funcCalled) == 0 })
+			assert.Equal(t, time.Unix(0, 500000000), clock.Now())
+
+			finishedBlocking = make(chan struct{})
+			go func() {
+				timer.BlockingAdvance(500 * time.Millisecond)
+				close(finishedBlocking)
+			}()
+			consistently(t, chanDoesNotReceive(timer.Chan()))
+			eventually(t, chanClosed(finishedBlocking))
+			eventually(t, func() bool { return atomic.LoadUint32(&funcCalled) == 1 })
+			assert.Equal(t, time.Unix(1, 0), clock.Now())
+		})
+	})
+	t.Run("afterfunc timer", func(t *testing.T) {
+		t.Run("runs on trigger", func(t *testing.T) {
+			funcCalled := uint32(0)
+
+			clock := NewMockClockAt(time.Unix(0, 0))
+			clock.AfterFunc(1*time.Second, func() {
+				atomic.AddUint32(&funcCalled, 1)
+			})
+			consistently(t, func() bool { return atomic.LoadUint32(&funcCalled) == 0 })
+
+			clock.Advance(500 * time.Millisecond)
+			consistently(t, func() bool { return atomic.LoadUint32(&funcCalled) == 0 })
+
+			clock.Advance(500 * time.Millisecond)
+			eventually(t, func() bool { return atomic.LoadUint32(&funcCalled) == 1 })
+		})
+		t.Run("runs after expiration and reset", func(t *testing.T) {
+			funcCalled := uint32(0)
+
+			clock := NewMockClockAt(time.Unix(0, 0))
+			timer := clock.AfterFunc(1*time.Second, func() {
+				atomic.AddUint32(&funcCalled, 1)
+			})
+
+			clock.Advance(1 * time.Second)
+			eventually(t, func() bool { return atomic.LoadUint32(&funcCalled) == 1 })
+
+			assert.False(t, timer.Reset(2*time.Second))
+
+			clock.Advance(1 * time.Second)
+			consistently(t, func() bool { return atomic.LoadUint32(&funcCalled) == 1 })
+
+			clock.Advance(1 * time.Second)
+			eventually(t, func() bool { return atomic.LoadUint32(&funcCalled) == 2 })
+		})
+		t.Run("does not run when stopped", func(t *testing.T) {
+			funcCalled := uint32(0)
+
+			clock := NewMockClockAt(time.Unix(0, 0))
+			timer := clock.AfterFunc(1*time.Second, func() {
+				atomic.AddUint32(&funcCalled, 1)
+			})
+
+			clock.Advance(500 * time.Millisecond)
+			consistently(t, func() bool { return atomic.LoadUint32(&funcCalled) == 0 })
+
+			assert.True(t, timer.Stop())
+			consistently(t, func() bool { return atomic.LoadUint32(&funcCalled) == 0 })
+
+			clock.Advance(1 * time.Second)
+			consistently(t, func() bool { return atomic.LoadUint32(&funcCalled) == 0 })
+		})
+		t.Run("extends timer when reset while running", func(t *testing.T) {
+			funcCalled := uint32(0)
+
+			clock := NewMockClockAt(time.Unix(0, 0))
+			timer := clock.AfterFunc(1*time.Second, func() {
+				atomic.AddUint32(&funcCalled, 1)
+			})
+
+			clock.Advance(500 * time.Millisecond)
+			consistently(t, func() bool { return atomic.LoadUint32(&funcCalled) == 0 })
+
+			assert.True(t, timer.Reset(1*time.Second))
+
+			clock.Advance(500 * time.Millisecond)
+			consistently(t, func() bool { return atomic.LoadUint32(&funcCalled) == 0 })
+
+			clock.Advance(500 * time.Millisecond)
+			eventually(t, func() bool { return atomic.LoadUint32(&funcCalled) == 1 })
+		})
+	})
+	t.Run("firing", func(t *testing.T) {
+		t.Run("on time", func(t *testing.T) {
+			t.Run("advance directly to trigger", func(t *testing.T) {
+				clock := NewMockClock()
+				clock.SetCurrent(time.Unix(0, 0))
+
+				timer := clock.NewTimer(1 * time.Second)
+				consistently(t, chanDoesNotReceive(timer.Chan()))
+
+				clock.Advance(1 * time.Second)
+				eventually(t, chanReceives(timer.Chan(), time.Unix(1, 0)))
+			})
+			t.Run("advance once before triggering", func(t *testing.T) {
+				clock := NewMockClock()
+				clock.SetCurrent(time.Unix(0, 0))
+
+				timer := clock.NewTimer(1 * time.Second)
+				consistently(t, chanDoesNotReceive(timer.Chan()))
+
+				clock.Advance(500 * time.Millisecond)
+				consistently(t, chanDoesNotReceive(timer.Chan()))
+
+				clock.Advance(500 * time.Millisecond)
+				eventually(t, chanReceives(timer.Chan(), time.Unix(1, 0)))
+			})
+		})
+		t.Run("after time", func(t *testing.T) {
+			t.Run("advance directly after first trigger", func(t *testing.T) {
+				clock := NewMockClock()
+				clock.SetCurrent(time.Unix(0, 0))
+
+				timer := clock.NewTimer(1 * time.Second)
+				consistently(t, chanDoesNotReceive(timer.Chan()))
+
+				clock.Advance(1*time.Second + 500*time.Millisecond)
+				eventually(t, chanReceives(timer.Chan(), time.Unix(1, 500000000)))
+			})
+			t.Run("advance directly past second trigger", func(t *testing.T) {
+				clock := NewMockClock()
+				clock.SetCurrent(time.Unix(0, 0))
+
+				timer := clock.NewTimer(1 * time.Second)
+				consistently(t, chanDoesNotReceive(timer.Chan()))
+
+				clock.Advance(2*time.Second + 500*time.Millisecond)
+				eventually(t, chanReceives(timer.Chan(), time.Unix(2, 500000000)))
+			})
+			t.Run("advance once before triggering", func(t *testing.T) {
+				clock := NewMockClock()
+				clock.SetCurrent(time.Unix(0, 0))
+
+				timer := clock.NewTimer(1 * time.Second)
+				consistently(t, chanDoesNotReceive(timer.Chan()))
+
+				clock.Advance(500 * time.Millisecond)
+				consistently(t, chanDoesNotReceive(timer.Chan()))
+
+				clock.Advance(1 * time.Second)
+				eventually(t, chanReceives(timer.Chan(), time.Unix(1, 500000000)))
+			})
+		})
+		t.Run("triggers once", func(t *testing.T) {
+			clock := NewMockClock()
+			clock.SetCurrent(time.Unix(0, 0))
+
+			timer := clock.NewTimer(1 * time.Second)
+			consistently(t, chanDoesNotReceive(timer.Chan()))
+
+			clock.Advance(1 * time.Second)
+			eventually(t, chanReceives(timer.Chan(), time.Unix(1, 0)))
+
+			clock.Advance(1 * time.Second)
+			consistently(t, chanDoesNotReceive(timer.Chan()))
+		})
+	})
+	t.Run("stopping", func(t *testing.T) {
+		t.Run("returns true when stopping timer", func(t *testing.T) {
+			clock := NewMockClock()
+			clock.SetCurrent(time.Unix(0, 0))
+
+			timer := clock.NewTimer(1 * time.Second)
+			clock.Advance(500 * time.Millisecond)
+
+			assert.True(t, timer.Stop())
+			consistently(t, chanDoesNotReceive(timer.Chan()))
+		})
+		t.Run("returns false when already expired", func(t *testing.T) {
+			clock := NewMockClock()
+			clock.SetCurrent(time.Unix(0, 0))
+
+			timer := clock.NewTimer(1 * time.Second)
+
+			clock.Advance(1 * time.Second)
+			eventually(t, chanReceives(timer.Chan(), time.Unix(1, 0)))
+
+			assert.False(t, timer.Stop())
+		})
+		t.Run("returns false when already stopped", func(t *testing.T) {
+			clock := NewMockClock()
+			clock.SetCurrent(time.Unix(0, 0))
+
+			timer := clock.NewTimer(1 * time.Second)
+
+			assert.True(t, timer.Stop())
+
+			clock.Advance(500 * time.Millisecond)
+			assert.False(t, timer.Stop())
+		})
+		t.Run("prevents timer from triggering", func(t *testing.T) {
+			clock := NewMockClock()
+			clock.SetCurrent(time.Unix(0, 0))
+
+			timer := clock.NewTimer(1 * time.Second)
+			consistently(t, chanDoesNotReceive(timer.Chan()))
+
+			clock.Advance(500 * time.Millisecond)
+			consistently(t, chanDoesNotReceive(timer.Chan()))
+
+			assert.True(t, timer.Stop())
+			consistently(t, chanDoesNotReceive(timer.Chan()))
+
+			clock.Advance(500 * time.Millisecond)
+			consistently(t, chanDoesNotReceive(timer.Chan()))
+		})
+	})
+	t.Run("resetting", func(t *testing.T) {
+		t.Run("returns true if timer was active", func(t *testing.T) {
+			clock := NewMockClock()
+			clock.SetCurrent(time.Unix(0, 0))
+
+			timer := clock.NewTimer(1 * time.Second)
+			clock.Advance(500 * time.Millisecond)
+
+			assert.True(t, timer.Reset(1*time.Second))
+		})
+		t.Run("returns false if timer had expired", func(t *testing.T) {
+			clock := NewMockClock()
+			clock.SetCurrent(time.Unix(0, 0))
+
+			timer := clock.NewTimer(1 * time.Second)
+
+			clock.Advance(1 * time.Second)
+			eventually(t, chanReceives(timer.Chan(), time.Unix(1, 0)))
+
+			assert.False(t, timer.Reset(1*time.Second))
+		})
+		t.Run("returns false if timer had been stopped", func(t *testing.T) {
+			clock := NewMockClock()
+			clock.SetCurrent(time.Unix(0, 0))
+
+			timer := clock.NewTimer(1 * time.Second)
+
+			assert.True(t, timer.Stop())
+			assert.False(t, timer.Reset(1*time.Second))
+		})
+		t.Run("runs again if timer had been stopped", func(t *testing.T) {
+			clock := NewMockClock()
+			clock.SetCurrent(time.Unix(0, 0))
+
+			timer := clock.NewTimer(1 * time.Second)
+
+			assert.True(t, timer.Stop())
+			assert.False(t, timer.Reset(1*time.Second))
+
+			clock.Advance(1 * time.Second)
+			eventually(t, chanReceives(timer.Chan(), time.Unix(1, 0)))
+		})
+		t.Run("runs again if timer had expired", func(t *testing.T) {
+			clock := NewMockClock()
+			clock.SetCurrent(time.Unix(0, 0))
+
+			timer := clock.NewTimer(1 * time.Second)
+
+			clock.Advance(1 * time.Second)
+			eventually(t, chanReceives(timer.Chan(), time.Unix(1, 0)))
+
+			assert.False(t, timer.Reset(1*time.Second))
+
+			clock.Advance(1 * time.Second)
+			eventually(t, chanReceives(timer.Chan(), time.Unix(2, 0)))
+		})
+	})
+}

--- a/real_clock.go
+++ b/real_clock.go
@@ -36,8 +36,10 @@ func (c *realClock) NewTicker(duration time.Duration) Ticker {
 	return NewRealTicker(duration)
 }
 
-func NewRealTicker(duration time.Duration) Ticker {
-	return &realTicker{
-		ticker: time.NewTicker(duration),
-	}
+func (c *realClock) NewTimer(duration time.Duration) Timer {
+	return NewRealTimer(duration)
+}
+
+func (c *realClock) AfterFunc(duration time.Duration, f func()) Timer {
+	return newRealTimer(time.AfterFunc(duration, f))
 }

--- a/real_ticker.go
+++ b/real_ticker.go
@@ -8,6 +8,12 @@ type realTicker struct {
 
 var _ Ticker = &realTicker{}
 
+func NewRealTicker(duration time.Duration) Ticker {
+	return &realTicker{
+		ticker: time.NewTicker(duration),
+	}
+}
+
 func (t *realTicker) Chan() <-chan time.Time {
 	return t.ticker.C
 }

--- a/real_timer.go
+++ b/real_timer.go
@@ -1,0 +1,30 @@
+package glock
+
+import "time"
+
+type realTimer struct {
+	timer *time.Timer
+}
+
+var _ Timer = &realTimer{}
+
+func NewRealTimer(duration time.Duration) Timer {
+	return newRealTimer(time.NewTimer(duration))
+}
+func newRealTimer(timer *time.Timer) Timer {
+	return &realTimer{
+		timer: timer,
+	}
+}
+
+func (t *realTimer) Chan() <-chan time.Time {
+	return t.timer.C
+}
+
+func (t *realTimer) Reset(duration time.Duration) bool {
+	return t.timer.Reset(duration)
+}
+
+func (t *realTimer) Stop() bool {
+	return t.timer.Stop()
+}

--- a/ticker.go
+++ b/ticker.go
@@ -1,0 +1,13 @@
+package glock
+
+import "time"
+
+// Ticker is a wrapper around a time.Ticker, which allows interface access to the
+// underlying channel (instead of bare access like the time.Ticker struct allows).
+type Ticker interface {
+	// Chan returns the underlying ticker channel.
+	Chan() <-chan time.Time
+
+	// Stop stops the ticker.
+	Stop()
+}

--- a/timer.go
+++ b/timer.go
@@ -1,0 +1,10 @@
+package glock
+
+import "time"
+
+type Timer interface {
+	Chan() <-chan time.Time
+
+	Reset(d time.Duration) bool
+	Stop() bool
+}


### PR DESCRIPTION
One of the implementations I'm working on uses time.AfterFunc, so I needed to add this to test that!